### PR TITLE
fix the issuer of OIDC tokens

### DIFF
--- a/provider/github-app-token/github/github.go
+++ b/provider/github-app-token/github/github.go
@@ -26,10 +26,10 @@ const (
 	// The default url of Github API
 	defaultAPIBaseURL = "https://api.github.com"
 
-	oidcIssuer = "https://vstoken.actions.githubusercontent.com"
+	oidcIssuer = "https://token.actions.githubusercontent.com"
 )
 
-// The thumbprint of the certificate for https://vstoken.actions.githubusercontent.com
+// The thumbprint of the certificate for https://token.actions.githubusercontent.com
 var oidcThumbprints = []string{"a031c46782e6e6c662c2c87c76da9aa62ccabd8e"}
 
 var apiBaseURL string

--- a/provider/github-app-token/github/oidc/config_test.go
+++ b/provider/github-app-token/github/oidc/config_test.go
@@ -31,7 +31,7 @@ func TestGetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := config.Issuer, "https://vstoken.actions.githubusercontent.com"; got != want {
+	if got, want := config.Issuer, "https://token.actions.githubusercontent.com"; got != want {
 		t.Errorf("unexpected issuer: want %q, got %q", want, got)
 	}
 }

--- a/provider/github-app-token/github/oidc/testdata/gha-openid-configuration.json
+++ b/provider/github-app-token/github/oidc/testdata/gha-openid-configuration.json
@@ -1,6 +1,6 @@
 {
-  "issuer": "https://vstoken.actions.githubusercontent.com",
-  "jwks_uri": "https://vstoken.actions.githubusercontent.com/.well-known/jwks",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "jwks_uri": "https://token.actions.githubusercontent.com/.well-known/jwks",
   "subject_types_supported": [
     "public",
     "pairwise"
@@ -15,7 +15,21 @@
     "iat",
     "iss",
     "jti",
-    "nbf"
+    "nbf",
+    "ref",
+    "repository",
+    "repository_owner",
+    "run_id",
+    "run_number",
+    "run_attempt",
+    "actor",
+    "workflow",
+    "head_ref",
+    "base_ref",
+    "event_name",
+    "ref_type",
+    "environment",
+    "job_workflow_ref"
   ],
   "id_token_signing_alg_values_supported": [
     "RS256"


### PR DESCRIPTION
The issuer changed from "https://vstoken.actions.githubusercontent.com" to "https://token.actions.githubusercontent.com"