### PR TITLE
bump Node.js v16

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "16.x"
           cache: "npm"
           cache-dependency-path: action/package-lock.json
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ outputs:
   token:
     description: An installation token for the GitHub App on the requested repository.
 runs:
-  using: "node12"
+  using: "node16"
   main: "action/lib/index.js"
   post: "action/lib/cleanup.js"
   post-if: always()

--- a/action/tsconfig.json
+++ b/action/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2021",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
GitHub Actions Runner supports Node.js v16 LTS from version 2.285.0

- https://github.com/actions/runner/pull/1439

I'm waiting for official announce.