### PR TITLE
ignore broken (or unknown type) public key

### DIFF
--- a/provider/github-app-token/github/jwk/jwks.go
+++ b/provider/github-app-token/github/jwk/jwks.go
@@ -16,11 +16,10 @@ func ParseSet(data []byte) (*Set, error) {
 
 	list := make([]Key, 0, len(keys.Keys))
 	for _, raw := range keys.Keys {
-		key, err := ParseKey(raw)
-		if err != nil {
-			return nil, err
+		if key, err := ParseKey(raw); err == nil {
+			list = append(list, key)
+			// Ignore keys that cannot be parsed.
 		}
-		list = append(list, key)
 	}
 	return &Set{
 		Keys: list,

--- a/provider/github-app-token/github/oidc/jwks.go
+++ b/provider/github-app-token/github/oidc/jwks.go
@@ -49,7 +49,7 @@ func (c *Client) GetJWKS(ctx context.Context, url string) (*jwk.Set, error) {
 
 		set, err := jwk.ParseSet(data)
 		if err != nil {
-
+			return nil, time.Time{}, err
 		}
 		return set, expiresAt, nil
 	})


### PR DESCRIPTION
A new key type may be added into the `kty` parameter in the future.
So, we should ignore unknown keys that have unknown `kty`.