### PR TITLE
introduce SSMParameterWithSlashPrefixReadPolicy

### DIFF
--- a/provider/template.yaml
+++ b/provider/template.yaml
@@ -41,9 +41,8 @@ Resources:
           GITHUB_APP_ID: !Ref AppId
           GITHUB_PRIVATE_KEY: !Ref PrivateKey
       Policies:
-        - SSMParameterReadPolicy:
-            # HACK: trim "/" prefix. See https://github.com/aws/serverless-application-model/issues/1112
-            ParameterName: !Join ["", !Split ["^/", !Sub "^${AppId}"]]
-        - SSMParameterReadPolicy:
-            ParameterName: !Join ["", !Split ["^/", !Sub "^${PrivateKey}"]]
+        - SSMParameterWithSlashPrefixReadPolicy:
+            ParameterName: !Ref AppId
+        - SSMParameterWithSlashPrefixReadPolicy:
+            ParameterName: !Ref PrivateKey
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess


### PR DESCRIPTION
because `SSMParameterWithSlashPrefixReadPolicy` is now available https://github.com/aws/serverless-application-model/pull/2693 , we can remove the hack for https://github.com/aws/serverless-application-model/issues/1112