### PR TITLE
introduce Grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
     directory: "/provider/github-app-token"
     schedule:
       interval: "daily"
+    groups:
+      aws-sdk:
+        patterns:
+          - github.com/aws/aws-sdk-go-v2
+          - github.com/aws/aws-sdk-go-v2/*
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
> Grouped version updates for Dependabot public beta

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/