### PR TITLE
docs: update README to include installation and deployment instructio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,7 @@ The action provides [the GitHub Token Vending API](./provider) to manage token p
 
 ### Install the GitHub App
 
-Create a new your own GitHub App, or install [My Demonstration App](https://github.com/apps/shogo82148-slim).
-
-### Deploy the GitHub Token Vending API
-
-[Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html),
-and deploy the API to your AWS Account.
-
-```
-cd provider/
-sam build
-sam deploy
-```
+Install [My Demonstration App](https://github.com/apps/shogo82148-slim).
 
 ### Use the Action in Your Workflow
 
@@ -49,9 +38,6 @@ jobs:
     steps:
       - id: generate
         uses: shogo82148/actions-github-app-token@v1
-        # Optional (defaults to My Demonstration App).
-        # with:
-        #   provider-endpoint: https://EXAMPLE.execute-api.us-east-1.amazonaws.com/
       - run: |
           gh issue create --title "Do something using GITHUB_TOKEN"
         env:
@@ -68,6 +54,11 @@ jobs:
    The long term credential doesn't leave AWS environment. It keeps the workflow safer.
 3. The vendor a new credential with JWT (JSON Web Token).
 4. GitHub returns a temporary credential.
+
+## Create your own GitHub Token Vending API
+
+If you own an AWS account, you can create the GitHub Token Vending API yourself.
+See [provider/README.md](./provider/README.md) for more detail.
 
 ## Related Works
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -1,1 +1,52 @@
-# Credential Provider
+# GitHub Token Vending API
+
+## How to install the API to your AWS Account
+
+### Create a new GitHub App on GitHub
+
+1. Open [GitHub Apps](https://github.com/settings/apps) page
+2. Click [New GitHub Apps](https://github.com/settings/apps/new) button
+3. Fill in the required fields and click the "Create GitHub App" button
+4. Make a note of the AppID.
+5. Click the "generate a private key" button under the Private keys section.
+
+### AWS and GitHub App integration settings
+
+Register the AppID and private key to the AWS account.
+
+Register the AppID:
+
+```bash
+aws ssm put-parameter \
+  --name "/github-app-token/app-id" \
+  --value "${YOUR_APP_ID}" \
+  --type "String"
+```
+
+Register the private key:
+
+```bash
+# Create a new KMS Key.
+aws kms create-key \
+    --key-spec RSA_2048 \
+    --key-usage SIGN_VERIFY \
+    --origin EXTERNAL \
+    --description "GitHub App JWT signing key"
+
+# import the private key.
+./import-key.sh "${KEY_ID}" ${PRIVATE_KEY_PEM}
+
+# create an alias.
+aws kms create-alias \
+    --alias-name alias/github-app \
+    --target-key-id "${KEY_ID}"
+```
+
+### Deploy the API
+
+```bash
+make oidc-provider
+make cicd
+make build
+make deploy
+```


### PR DESCRIPTION
…ns for GitHub Token Vending API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README structure: "Install the GitHub App" section now directs users to provider setup guide.
  * Added comprehensive GitHub Token Vending API deployment guide with step-by-step AWS setup instructions (SSM, KMS configuration, and deployment commands).
  * Simplified main README by separating basic app installation from advanced provider deployment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->